### PR TITLE
split showTooltip into two functions, prevent onFocus when clicked

### DIFF
--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -34,11 +34,16 @@ export class EuiToolTip extends Component {
     this.space = props.space || 16;
 
     this.showToolTip = this.showToolTip.bind(this);
+    this.positionToolTip = this.positionToolTip.bind(this);
     this.hideToolTip = this.hideToolTip.bind(this);
     this.toggleToolTipVisibility = this.toggleToolTipVisibility.bind(this);
   }
 
-  showToolTip(toolTipRect) {
+  showToolTip() {
+    this.setState({ visible: true });
+  }
+
+  positionToolTip(toolTipRect) {
     const wrapperRect = this.wrapper.getBoundingClientRect();
     const userPosition = this.props.position;
 
@@ -56,7 +61,8 @@ export class EuiToolTip extends Component {
     this.setState({ visible: false });
   }
 
-  toggleToolTipVisibility() {
+  toggleToolTipVisibility(event) {
+    event.preventDefault();
     this.setState(prevState => ({
       visible: !prevState.visible
     }));
@@ -86,7 +92,7 @@ export class EuiToolTip extends Component {
           <EuiToolTipPopover
             className={classes}
             style={this.state.toolTipStyles}
-            showToolTip={this.showToolTip}
+            positionToolTip={this.positionToolTip}
             title={title}
             id={this.state.id}
             role="tooltip"
@@ -100,8 +106,11 @@ export class EuiToolTip extends Component {
 
     let toolTipProps;
     if (clickOnly) {
+      // react fires onFocus before onClick, but onMouseDown gets called before onFocus
+      // using onMouseDown so handler gets called before onFocus
+      // https://stackoverflow.com/a/28963938/890809
       toolTipProps = {
-        onClick: this.toggleToolTipVisibility
+        onMouseDown: this.toggleToolTipVisibility
       };
     } else {
       toolTipProps = {

--- a/src/components/tool_tip/tool_tip_popover.js
+++ b/src/components/tool_tip/tool_tip_popover.js
@@ -9,7 +9,7 @@ export class EuiToolTipPopover extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     title: PropTypes.node,
-    showToolTip: PropTypes.func,
+    positionToolTip: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -20,7 +20,7 @@ export class EuiToolTipPopover extends Component {
     document.body.classList.add('euiBody-hasToolTip');
 
     requestAnimationFrame(() => {
-      this.props.showToolTip(this.popover.getBoundingClientRect());
+      this.props.positionToolTip(this.popover.getBoundingClientRect());
     });
   }
 
@@ -34,7 +34,7 @@ export class EuiToolTipPopover extends Component {
       title,
       className,
       /* eslint-disable */
-      showToolTip,
+      positionToolTip,
       /* eslint-enable */
       ...rest
     } = this.props;


### PR DESCRIPTION
Fixes problem of showTooltip getting called with shadow DOM. Fixes need for second click to open tooltip