### PR TITLE
WIP: pass `setGridStyles` through

### DIFF
--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -200,7 +200,14 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   } = props;
 
   const [ColumnSelector, visibleColumns] = useColumnSelector(columns);
-  const [StyleSelector, gridStyles] = useStyleSelector(gridStyle);
+  const [StyleSelector, gridStyles, setGridStyles] = useStyleSelector(
+    gridStyle
+  );
+  useEffect(() => {
+    if (gridStyle) {
+      setGridStyles(gridStyle);
+    }
+  }, [gridStyle]);
 
   const classes = classNames(
     'euiDataGrid',

--- a/src/components/datagrid/style_selector.tsx
+++ b/src/components/datagrid/style_selector.tsx
@@ -1,11 +1,14 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, {
+  Dispatch,
+  FunctionComponent,
+  SetStateAction,
+  useState,
+} from 'react';
 import { EuiDataGridStyle } from './data_grid_types';
 // @ts-ignore-next-line
 import { EuiPopover } from '../popover';
 // @ts-ignore-next-line
-import { EuiButtonEmpty } from '../button';
-// @ts-ignore-next-line
-import { EuiButtonGroup } from '../button';
+import { EuiButtonEmpty, EuiButtonGroup } from '../button';
 
 export const useStyleSelector = (
   initialStyles: EuiDataGridStyle = {
@@ -16,7 +19,11 @@ export const useStyleSelector = (
     rowHover: 'highlight',
     header: 'shade',
   }
-): [FunctionComponent<any>, EuiDataGridStyle] => {
+): [
+  FunctionComponent<any>,
+  EuiDataGridStyle,
+  Dispatch<SetStateAction<EuiDataGridStyle>>
+] => {
   const [gridStyles, setGridStyles] = useState(initialStyles);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -75,7 +82,7 @@ export const useStyleSelector = (
     setGridDensity(optionId);
 
     const selectedDensity = densityOptions.filter(options => {
-      return options.id == optionId;
+      return options.id === optionId;
     })[0];
     setGridStyles(selectedDensity.density);
   };
@@ -110,5 +117,5 @@ export const useStyleSelector = (
     </EuiPopover>
   );
 
-  return [StyleSelector, gridStyles];
+  return [StyleSelector, gridStyles, setGridStyles];
 };


### PR DESCRIPTION
This gets you closer to what you want: components that use `useStyleSelector` can optionally pass it a new config when props change. `useEffect` watches for prop changes; the now available `setGridStyles` function updates the hook value(s).

You'll see, though, that odd things happen in the docs when you attempt to change styles with the different methods. This is because the _full_  style config is getting changed each time. You'll need some kind of reconciliation step to determine what style(s) were intended to be changed, which _might_ be tricky.